### PR TITLE
Fix CI workflows and XSS vulnerabilities in archive rendering

### DIFF
--- a/.github/workflows/deploy-herenow.yml
+++ b/.github/workflows/deploy-herenow.yml
@@ -1,6 +1,8 @@
 name: Deploy to here.now
 
 on:
+  schedule:
+    - cron: '15 0 * * *'   # 00:15 UTC daily — after update-quote runs at 00:00
   push:
     branches:
       - master

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -35,6 +35,12 @@ jobs:
         with:
           ref: master
 
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.5'
+          extensions: sqlite3
+
       - name: Configure GitHub Pages
         uses: actions/configure-pages@v5
 

--- a/.github/workflows/update-quote.yml
+++ b/.github/workflows/update-quote.yml
@@ -5,6 +5,9 @@ on:
     - cron: '0 0 * * *' # Runs every day at midnight UTC
   workflow_dispatch: # Allows manual triggering
 
+permissions:
+  contents: write
+
 jobs:
   update-quote:
     runs-on: ubuntu-latest

--- a/index.html
+++ b/index.html
@@ -8,6 +8,7 @@
     <meta property="og:title" content="مقولات من خيرة العرب">
     <meta property="og:description" content="أرشيف عربي مفتوح للحكم والمقولات، مع اختيار يومي عادل وواجهة بحث جاهزة للنشر.">
     <meta property="og:image" content="assets/arabicquotes-header.jpg">
+    <meta property="og:url" content="https://aq.aldoy.net/">
     <meta property="og:type" content="website">
     <link rel="icon" href="favicon.svg" type="image/svg+xml">
     <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -542,13 +543,19 @@
             const text = clean(quote.quote);
             const author = clean(quote.author) || "غير معروف";
             const category = clean(quote.category) || "عام";
-            article.innerHTML = `
-                <p>${text}</p>
-                <footer>
-                    <span>${author}</span>
-                    <span class="tag">${category}</span>
-                </footer>
-            `;
+
+            const p = document.createElement("p");
+            p.textContent = text;
+
+            const footer = document.createElement("footer");
+            const authorSpan = document.createElement("span");
+            authorSpan.textContent = author;
+            const categorySpan = document.createElement("span");
+            categorySpan.className = "tag";
+            categorySpan.textContent = category;
+            footer.append(authorSpan, categorySpan);
+
+            article.append(p, footer);
             return article;
         }
 
@@ -580,16 +587,33 @@
             if (!state.quotes.length) return;
             const quote = state.quotes[Math.floor(Math.random() * state.quotes.length)];
             const container = document.getElementById("quote-container");
-            container.innerHTML = `
-                <div class="daily-quote-card" data-quote-id="${quote.id || ""}" data-hits="${Number(quote.hits || 0)}">
-                    <div class="quote-mark" aria-hidden="true">"</div>
-                    <p class="quote-text">${clean(quote.quote)}</p>
-                    <div class="quote-meta">
-                        <strong class="author-text">${clean(quote.author) || "غير معروف"}</strong>
-                        <span class="selection-count">اختيرت ${formatNumber(Number(quote.hits || 0))} مرة</span>
-                    </div>
-                </div>
-            `;
+
+            const card = document.createElement("div");
+            card.className = "daily-quote-card";
+            card.dataset.quoteId = quote.id || "";
+            card.dataset.hits = Number(quote.hits || 0);
+
+            const mark = document.createElement("div");
+            mark.className = "quote-mark";
+            mark.setAttribute("aria-hidden", "true");
+            mark.textContent = "“";
+
+            const p = document.createElement("p");
+            p.className = "quote-text";
+            p.textContent = clean(quote.quote);
+
+            const meta = document.createElement("div");
+            meta.className = "quote-meta";
+            const strong = document.createElement("strong");
+            strong.className = "author-text";
+            strong.textContent = clean(quote.author) || "غير معروف";
+            const count = document.createElement("span");
+            count.className = "selection-count";
+            count.textContent = "اختيرت " + formatNumber(Number(quote.hits || 0)) + " مرة";
+            meta.append(strong, count);
+
+            card.append(mark, p, meta);
+            container.replaceChildren(card);
         }
 
         function copyDailyQuote() {


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **`deploy-pages.yml`** — added missing PHP setup step; the build script calls `php scripts/build-site.php` but PHP was never installed, so every Pages deploy was broken
- **`update-quote.yml`** — added `permissions: contents: write` so the daily quote commit/push can actually succeed
- **`deploy-herenow.yml`** — added `schedule: '15 0 * * *'` (00:15 UTC daily) so here.now refreshes independently every day, not just when a push or `workflow_run` fires
- **`index.html`** — rewrote `quoteCard()` and `setRandomQuote()` to use DOM APIs (`textContent`, `createElement`, `append`) instead of `innerHTML` with user data; HTML-entity-encoded content in quotes.json was being decoded by `clean()` and then re-injected unsanitised, creating a real XSS vector
- **`index.html`** — added `og:url` meta tag pointing to `https://aq.aldoy.net/`

## Test plan

- [ ] Manually trigger **Update Quote of the Day** → confirm it commits and pushes without permission errors
- [ ] Manually trigger **Deploy to GitHub Pages** → confirm build succeeds (PHP step now present)
- [ ] Manually trigger **Deploy to here.now** → confirm site URL is printed in the step summary
- [ ] Confirm **Deploy to here.now** also runs automatically at 00:15 UTC via the new schedule
- [ ] Verify archive grid renders correctly and no XSS is possible with crafted quote content

https://claude.ai/code/session_01JkYxm148XVBaoF27iTmKib
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JkYxm148XVBaoF27iTmKib)_