### PR TITLE
docs: stop hardcoding the here.now slug in docs/index.html

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -47,8 +47,7 @@
         <section class="card">
             <h2>النشر</h2>
             <p>يتم بناء مجلد <code>_site</code> أولا، ثم تستخدمه GitHub Pages وhere.now حتى تكون النسختان من نفس المصدر المنشور.</p>
-            <p>يتطلب here.now السر <code>HERENOW_API_KEY</code> حتى يكون الموقع دائما، ويمكن ضبط <code>HERENOW_SLUG</code> لتحديث موقع قائم.</p>
-            <p>الموقع الدائم الحالي على here.now: <a href="https://lapis-waffle-fytj.here.now/">https://lapis-waffle-fytj.here.now/</a></p>
+            <p>يتطلب here.now السر <code>HERENOW_API_KEY</code> حتى يكون الموقع دائما. رابط الموقع الحالي على here.now مذكور دائما في <a href="../README.md">README.md</a>، لأنه يتحدث تلقائيا مع كل نشر.</p>
         </section>
 
         <div class="links">


### PR DESCRIPTION
## Summary

Follow-up to #45. Validated the workflow fix in CI by dispatching `deploy-pages.yml` and `deploy-herenow.yml` against master — both succeeded, and the self-heal fired exactly as designed: `lapis-waffle-fytj` 404'd, the script created a new site, and `.github/herenow-site.json` / `README.md` now correctly point at `gentle-hollow-zwks.here.now`.

That rotation immediately exposed one more stale hardcode: `docs/index.html` still linked the old dead URL directly (it isn't auto-updated by the workflow, only `README.md` is). Replaced it with a pointer to `README.md` instead of a slug that will drift again on the next rotation.

## Test plan

- [x] `deploy-pages.yml` succeeded on master (PHP 8.3)
- [x] `deploy-herenow.yml` succeeded on master, self-healed to a new slug, committed `.github/herenow-site.json` + `README.md`
- [x] A second, near-simultaneous run confirmed idempotency: PUT to the now-correct slug succeeded directly, no rotation warning fired
- [ ] **Action needed from repo owner:** point `maqeel.aldoy.net`'s DNS/CNAME at `gentle-hollow-zwks.here.now` (the old `lapis-waffle-fytj` target no longer exists)


---
_Generated by [Claude Code](https://claude.ai/code/session_011gGNYcHSkuKXDYzbYQ2kHf)_